### PR TITLE
Display thicker traces

### DIFF
--- a/src/trace.py
+++ b/src/trace.py
@@ -104,5 +104,5 @@ class Trace:
 
         return go.Scattergeo(mode=mode, lon=lons, lat=lats, text=text,
                              name=f'{name}[{ip}, {hits} packets, {byte_count} bytes]',
-                             line={'width': int(math.log(byte_count)) / 5},
+                             line={'width': int(math.log(byte_count)) / 2},
                              marker={'size': marker_size, 'symbol': 'square'})


### PR DESCRIPTION
Trace thickness depends on the amount of data flow. However, currently, the difference is not clearly visible.
So now we divide thickness by 2 instead of 5.